### PR TITLE
fix: AttributeError when requesting XML

### DIFF
--- a/doi2ietf/utils.py
+++ b/doi2ietf/utils.py
@@ -177,7 +177,7 @@ def xml_author_tag(person, role=''):
         # https://github.com/cabo/kramdown-rfc2629/blob/d006536e2bab3aa9b8a70464710a725ca98a3051/lib/kramdown-rfc/refxml.rb#L50
         # do we need to copy that "heuristic" method?
         output += '<author surname="%s"' % (
-            escape(person['name'])
+            escape(person['name'] or '')
         )
 
     if role:


### PR DESCRIPTION
This is not a proper fix for #9. After this, author information is missing, but we avoid an exception.