### PR TITLE
Fail loudly instead of returning empty list

### DIFF
--- a/doi2ietf/utils.py
+++ b/doi2ietf/utils.py
@@ -235,9 +235,9 @@ def fetch_doi_data(lst):
             req = requests.get(doi_url, headers=HEADERS)
 
         except requests.exceptions.RequestException as err:
-            print("Unable to get %s" % doi_url)
-            print(err)
-
+            raise
+            # print("Unable to get %s" % doi_url)
+            # print(err)
             # raise SystemExit(err) ?
 
         else:
@@ -249,8 +249,8 @@ def fetch_doi_data(lst):
                 json_data = req.json()
 
             except JSONDecodeError:
-                print("Unable to decode response from: %s " % doi_url)
-
+                raise
+                # print("Unable to decode response from: %s " % doi_url)
                 # raise SystemExit(err) ?
 
             if json_data:

--- a/doi2ietf/utils.py
+++ b/doi2ietf/utils.py
@@ -241,6 +241,10 @@ def fetch_doi_data(lst):
             # raise SystemExit(err) ?
 
         else:
+            if req.status_code == 503:
+                raise RuntimeError("Source is unavailable (503)")
+            if req.status_code == 500:
+                raise RuntimeError("Source reports server error (500)")
             try:
                 json_data = req.json()
 

--- a/doi2ietf/utils.py
+++ b/doi2ietf/utils.py
@@ -248,6 +248,7 @@ def fetch_doi_data(lst):
             try:
                 json_data = req.json()
 
+            # TODO: Can use requests.exceptions.JSONDecodeError when it’s released
             except JSONDecodeError:
                 raise
                 # print("Unable to decode response from: %s " % doi_url)


### PR DESCRIPTION
Addresses the situation in #12. Now ConnectionError, JSONDecodeError will be re-raised and can be caught by callers. 503, 500 are raised as RuntimeError.

Proper fix is probably to enumerate relevant errors, define custom error classes and raise them, so that callers can handle these conditions without having to import various exceptions from different places.